### PR TITLE
fix: create the drivers on the right pointer

### DIFF
--- a/tasks/BMP280Task.cpp
+++ b/tasks/BMP280Task.cpp
@@ -30,7 +30,7 @@ bool BMP280Task::configureHook()
     auto i2c = make_unique<I2CBus>(i2c_conf.device_path);
     i2c->setTimeout(i2c_conf.timeout);
 
-    auto device = make_unique<BMP280>(*m_i2c, _i2c_address.get());
+    auto device = make_unique<BMP280>(*i2c, _i2c_address.get());
     device->sleepAndWriteConfiguration(_configuration.get());
 
     m_device = move(device);

--- a/tasks/PCA9685Task.cpp
+++ b/tasks/PCA9685Task.cpp
@@ -59,7 +59,7 @@ bool PCA9685Task::configureHook()
     auto i2c = make_unique<I2CBus>(i2c_conf.device_path);
     i2c->setTimeout(i2c_conf.timeout);
 
-    auto device = make_unique<PCA9685>(*m_i2c, _i2c_address.get());
+    auto device = make_unique<PCA9685>(*i2c, _i2c_address.get());
     device->writeSleepMode();
     device->writePrescale(conf.prescale);
 


### PR DESCRIPTION
Was created on the not-yet-initialized m_i2c
