### PR TITLE
fix: rework how stop/timeout values are generated

### DIFF
--- a/i2clib.orogen
+++ b/i2clib.orogen
@@ -34,6 +34,8 @@ task_context "PCA9685Task" do
     output_port "status", "/raw_io/PWMDutyDurations"
 
     port_driven timeout: 0.1
+
+    exception_states "INVALID_INPUT_SIZE"
 end
 
 # Driver for the BMP280, a Bosch pressure sensor

--- a/i2clibTypes.hpp
+++ b/i2clibTypes.hpp
@@ -71,26 +71,37 @@ namespace i2clib {
          */
         std::vector<PWMRange> ranges{PWMRange()};
 
-        /** Structure containing the expected behaviour on timeout and stop */
-        struct PWMAutoBehaviour : public PWMRange {
-            /** Value written on the PWM if no commands have been received for \c timeout
-             * It is also the value written on component start
+        /** Configuration of automated behaviours (init, stop and timeout) */
+        struct PWMAutoCommand {
+            enum Mode {
+                MODE_KEEP = 0,
+                MODE_SET = 1
+            };
+
+            Mode timeout_mode = MODE_KEEP;
+
+            /** Value written on the PWM on timeout if timeout_mode is MODE_SET.
+             * It is used as an initialization value on component start if the mode
+             * is MODE_KEEP.
              */
-            uint32_t on_duration = 0;
+            uint32_t timeout_on_duration = 0;
+
+            Mode stop_mode = MODE_KEEP;
+
+            /** Value written on the PWM on stop if stop_mode is MODE_SET.
+             */
+            uint32_t stop_on_duration = 0;
         };
 
-        /** Duration after which the component will write \c timeout_on_duration
-         * on the PWMs
+        /** Duration after which the component will write the configured timeout
+         * values
          */
         base::Time timeout{base::Time::fromMilliseconds(100)};
 
-        /** Per-PWM parameter for timeout behaviour
+        /** Per-PWM parameter for init, timeout and stop behaviour. It has to have the
+         * same size as the expected command vector
          */
-        std::vector<PWMAutoBehaviour> timeout_behaviour;
-
-        /** Per-PWM parameter for stop behaviour
-         */
-        std::vector<PWMAutoBehaviour> stop_behaviour;
+        std::vector<PWMAutoCommand> auto_behaviours;
     };
 
     struct MS5837Configuration {

--- a/tasks/PCA9685Helpers.cpp
+++ b/tasks/PCA9685Helpers.cpp
@@ -61,15 +61,3 @@ std::vector<MappedCommand> i2clib::pca9685helpers::mapCommand(
     }
     return result;
 }
-
-pair<vector<PWMRange>, raw_io::PWMDutyDurations> i2clib::pca9685helpers::
-    convertAutoBehaviour(vector<PCA9685Configuration::PWMAutoBehaviour> const& behaviour)
-{
-    vector<PWMRange> ranges;
-    raw_io::PWMDutyDurations command;
-    for (auto const& b : behaviour) {
-        ranges.push_back(b);
-        command.on_durations.resize(command.on_durations.size() + b.size, b.on_duration);
-    }
-    return make_pair(ranges, command);
-}

--- a/tasks/PCA9685Helpers.hpp
+++ b/tasks/PCA9685Helpers.hpp
@@ -40,13 +40,6 @@ namespace i2clib {
         std::vector<MappedCommand> mapCommand(
             std::vector<PCA9685Configuration::PWMRange> const& ranges,
             raw_io::PWMDutyDurations const& durations);
-
-        /** Convert the task's timeout/stop behaviour specification into commands
-         * compatible with \c mapCommand
-         */
-        std::pair<std::vector<PCA9685Configuration::PWMRange>, raw_io::PWMDutyDurations>
-        convertAutoBehaviour(
-            std::vector<PCA9685Configuration::PWMAutoBehaviour> const& behaviour);
     };
 }
 

--- a/tasks/PCA9685Task.cpp
+++ b/tasks/PCA9685Task.cpp
@@ -115,7 +115,9 @@ void PCA9685Task::writeCommand(PWMDutyDurations const& cmd,
         m_device->writeDutyTimes(m.pwm, m.durations, m_pwm_period);
     }
 
-    _status.write(cmd);
+    auto status = cmd;
+    status.time = base::Time::now();
+    _status.write(status);
 }
 void PCA9685Task::errorHook()
 {

--- a/tasks/PCA9685Task.hpp
+++ b/tasks/PCA9685Task.hpp
@@ -12,8 +12,10 @@ namespace i2clib {
     class PCA9685Task : public PCA9685TaskBase {
         friend class PCA9685TaskBase;
 
-        using PWMRange = PCA9685Configuration::PWMRange;
+        using Conf = PCA9685Configuration;
+        using PWMRange = Conf::PWMRange;
         using PWMDutyDurations = raw_io::PWMDutyDurations;
+        using PWMAutoCommand = Conf::PWMAutoCommand;
 
     protected:
         std::unique_ptr<I2CBus> m_i2c;
@@ -22,12 +24,13 @@ namespace i2clib {
 
         raw_io::PWMDutyDurations m_cmd;
         std::vector<PWMRange> m_ranges;
+        size_t m_expected_command_size = 0;
 
-        std::vector<PWMRange> m_stop_ranges;
-        PWMDutyDurations m_stop_command;
-
-        std::vector<PWMRange> m_timeout_ranges;
-        PWMDutyDurations m_timeout_command;
+        std::vector<PWMAutoCommand> m_auto_behaviours;
+        PWMDutyDurations applyAutoValues(PWMDutyDurations const& current,
+            std::vector<PWMAutoCommand> const& auto_cmd,
+            PWMAutoCommand::Mode PWMAutoCommand::*mode_field,
+            uint32_t PWMAutoCommand::*duration_field);
 
         base::Time m_timeout;
         base::Time m_deadline;

--- a/test/test_PCA9685Helpers.cpp
+++ b/test/test_PCA9685Helpers.cpp
@@ -9,7 +9,6 @@ using namespace raw_io;
 using namespace std;
 
 using PWMRange = PCA9685Configuration::PWMRange;
-using PWMAutoBehaviour = PCA9685Configuration::PWMAutoBehaviour;
 
 struct PCA9685HelpersTest : public ::testing::Test {};
 
@@ -98,21 +97,4 @@ TEST_F(PCA9685HelpersTest, it_throws_if_the_input_command_is_too_big)
     };
 
     ASSERT_THROW(pca9685helpers::mapCommand(ranges, cmd), std::invalid_argument);
-}
-
-TEST_F(PCA9685HelpersTest,
-    it_converts_the_timeout_specification_into_commands_compatible_with_mapCommand)
-{
-    vector<PWMAutoBehaviour> spec = {
-        PWMAutoBehaviour{PWMRange{.start = 1, .size = 2}, .on_duration = 5},
-        PWMAutoBehaviour{PWMRange{.start = 4, .size = 3}, .on_duration = 2}
-    };
-    auto result = pca9685helpers::convertAutoBehaviour(spec);
-    auto commands = pca9685helpers::mapCommand(result.first, result.second);
-
-    ASSERT_EQ(2, commands.size());
-    ASSERT_EQ(1, commands[0].pwm);
-    EXPECT_THAT(commands[0].durations, testing::ContainerEq(vector<uint32_t>{5, 5}));
-    ASSERT_EQ(4, commands[1].pwm);
-    EXPECT_THAT(commands[1].durations, testing::ContainerEq(vector<uint32_t>{2, 2, 2}));
 }


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-i2clib/pull/6

The current implementation does not guarantee that the output value will always have the same size than the input value ... since stop and timeout have different specifications than the 'normal' ranges.

Now that I realized this need, I rewrote the configuration structure for stop/timeout to specify every single PWM separately as either KEEP (do not write) or SET (change). This makes things simpler and clearer.
